### PR TITLE
Style improvements - sidebar, grid, picker, markdown

### DIFF
--- a/maths-club-app/src/app/app.component.html
+++ b/maths-club-app/src/app/app.component.html
@@ -1,20 +1,17 @@
-<div class="container">
-  <mat-toolbar color="primary">
+<div class="container" [class.is-mobile]="mobileWidthQuery.matches">
+  <mat-toolbar color="primary" >
     <button mat-icon-button (click)="snav.toggle()">
       <mat-icon>menu</mat-icon>
     </button>
-    <span>SAMI Maths App</span>
-    <span class="spacer"></span>
-    <span>
-      <app-language-switcher></app-language-switcher>
-    </span>
+    <span style="flex: 1;">SAMI Maths Club</span>
+    <app-language-switcher></app-language-switcher>
   </mat-toolbar>
 
-  <mat-sidenav-container class="sidenav-container">
+  <mat-sidenav-container>
     <mat-sidenav
       #snav
-      [mode]="mobileQuery.matches ? 'over' : 'side'"
-      [opened]="mobileQuery.matches ? false : true"
+      [mode]="mobileWidthQuery.matches ? 'over' : 'side'"
+      [opened]="mobileWidthQuery.matches ? false : true"
     >
       <mat-nav-list>
         <a mat-list-item routerLink="/">
@@ -29,5 +26,3 @@
     </mat-sidenav-content>
   </mat-sidenav-container>
 </div>
-
-<!--<router-outlet></router-outlet> -->

--- a/maths-club-app/src/app/app.component.html
+++ b/maths-club-app/src/app/app.component.html
@@ -1,28 +1,20 @@
-<div class="container" [class.is-mobile]="mobileWidthQuery.matches">
-  <mat-toolbar color="primary" >
-    <button mat-icon-button (click)="snav.toggle()">
-      <mat-icon>menu</mat-icon>
-    </button>
-    <span style="flex: 1;">SAMI Maths Club</span>
-    <app-language-switcher></app-language-switcher>
-  </mat-toolbar>
-
-  <mat-sidenav-container>
-    <mat-sidenav
-      #snav
-      [mode]="mobileWidthQuery.matches ? 'over' : 'side'"
-      [opened]="mobileWidthQuery.matches ? false : true"
-    >
-      <mat-nav-list>
-        <a mat-list-item routerLink="/">
-          <mat-icon>home</mat-icon>
-          Problems
-        </a>
-      </mat-nav-list>
-    </mat-sidenav>
-
-    <mat-sidenav-content>
-      <router-outlet></router-outlet>
-    </mat-sidenav-content>
-  </mat-sidenav-container>
-</div>
+<mat-sidenav-container>
+  <mat-sidenav #snav mode="over">
+    <mat-nav-list>
+      <a mat-list-item routerLink="/">
+        <mat-icon>home</mat-icon>
+        Problems
+      </a>
+    </mat-nav-list>
+  </mat-sidenav>
+  <mat-sidenav-content>
+    <mat-toolbar color="primary">
+      <button mat-icon-button (click)="snav.toggle()">
+        <mat-icon>menu</mat-icon>
+      </button>
+      <span style="flex: 1; text-align: center;">SAMI Maths Club</span>
+      <app-language-switcher></app-language-switcher>
+    </mat-toolbar>
+    <router-outlet></router-outlet>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/maths-club-app/src/app/app.component.scss
+++ b/maths-club-app/src/app/app.component.scss
@@ -1,33 +1,13 @@
 @import "~material-design-icons/iconfont/material-icons.css";
-// Layout adaped from:
-// https://v9.material.angular.io/components/sidenav/overview#creating-a-responsive-layout-for-mobile--desktop
 
-.container {
-  display: flex;
-  flex-direction: column;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background-color: #eee;
-}
-
-.sidenav-container {
-  flex: 1;
+mat-sidenav-container {
+  height: 100%;
 }
 
 mat-sidenav {
   width: 200px;
 }
 
-.is-mobile mat-sidenav-container {
-  /* When the sidenav is fixed, don't constrain the height of the sidenav container. This allows the
-     `<body>` to be our scrolling element for mobile layouts. */
-  flex: 1 0 auto;
-}
-.is-mobile mat-toolbar {
-  position: fixed;
-  /* Make sure the toolbar will stay on top of the content as it scrolls past. */
-  z-index: 2;
+mat-sidenav-content {
+  overflow-x: hidden;
 }

--- a/maths-club-app/src/app/app.component.scss
+++ b/maths-club-app/src/app/app.component.scss
@@ -1,4 +1,6 @@
 @import "~material-design-icons/iconfont/material-icons.css";
+// Layout adaped from:
+// https://v9.material.angular.io/components/sidenav/overview#creating-a-responsive-layout-for-mobile--desktop
 
 .container {
   display: flex;
@@ -15,6 +17,17 @@
   flex: 1;
 }
 
-.spacer {
-  flex: 1 1 auto;
+mat-sidenav {
+  width: 200px;
+}
+
+.is-mobile mat-sidenav-container {
+  /* When the sidenav is fixed, don't constrain the height of the sidenav container. This allows the
+     `<body>` to be our scrolling element for mobile layouts. */
+  flex: 1 0 auto;
+}
+.is-mobile mat-toolbar {
+  position: fixed;
+  /* Make sure the toolbar will stay on top of the content as it scrolls past. */
+  z-index: 2;
 }

--- a/maths-club-app/src/app/app.component.ts
+++ b/maths-club-app/src/app/app.component.ts
@@ -1,24 +1,11 @@
-import { Component, ChangeDetectorRef, OnDestroy } from "@angular/core";
-import { MediaMatcher } from "@angular/cdk/layout";
+import { Component, ViewEncapsulation } from "@angular/core";
 
 @Component({
   selector: "app-root",
   templateUrl: "./app.component.html",
   styleUrls: ["./app.component.scss"],
+  encapsulation: ViewEncapsulation.None,
 })
-export class AppComponent implements OnDestroy {
+export class AppComponent {
   title = "SAMI Maths Club App";
-  mobileWidthQuery: MediaQueryList;
-
-  private mobileWidthQueryListener: () => void;
-
-  constructor(changeDetectorRef: ChangeDetectorRef, media: MediaMatcher) {
-    this.mobileWidthQuery = media.matchMedia("(max-width: 990px)");
-    this.mobileWidthQueryListener = () => changeDetectorRef.detectChanges();
-    this.mobileWidthQuery.addListener(this.mobileWidthQueryListener);
-  }
-
-  ngOnDestroy() {
-    this.mobileWidthQuery.removeListener(this.mobileWidthQueryListener);
-  }
 }

--- a/maths-club-app/src/app/app.component.ts
+++ b/maths-club-app/src/app/app.component.ts
@@ -1,7 +1,5 @@
 import { Component, ChangeDetectorRef, OnDestroy } from "@angular/core";
 import { MediaMatcher } from "@angular/cdk/layout";
-import { ActivatedRoute, Router, ActivationEnd } from "@angular/router";
-import { ProblemService } from "./services/problem.service";
 
 @Component({
   selector: "app-root",
@@ -10,17 +8,17 @@ import { ProblemService } from "./services/problem.service";
 })
 export class AppComponent implements OnDestroy {
   title = "SAMI Maths Club App";
-  mobileQuery: MediaQueryList;
+  mobileWidthQuery: MediaQueryList;
 
-  private mobileQueryListener: () => void;
+  private mobileWidthQueryListener: () => void;
 
   constructor(changeDetectorRef: ChangeDetectorRef, media: MediaMatcher) {
-    this.mobileQuery = media.matchMedia("(max-width: 990px)");
-    this.mobileQueryListener = () => changeDetectorRef.detectChanges();
-    this.mobileQuery.addListener(this.mobileQueryListener);
+    this.mobileWidthQuery = media.matchMedia("(max-width: 990px)");
+    this.mobileWidthQueryListener = () => changeDetectorRef.detectChanges();
+    this.mobileWidthQuery.addListener(this.mobileWidthQueryListener);
   }
 
   ngOnDestroy() {
-    this.mobileQuery.removeListener(this.mobileQueryListener);
+    this.mobileWidthQuery.removeListener(this.mobileWidthQueryListener);
   }
 }

--- a/maths-club-app/src/app/components/language-switcher/language-switcher.component.html
+++ b/maths-club-app/src/app/components/language-switcher/language-switcher.component.html
@@ -1,15 +1,12 @@
-<div class="form">
-  <mat-form-field appearance="none">
-    <mat-select
-      class="select"
-      [(ngModel)]="language"
-      name="language"
-      [compareWith]="compareObjects"
-      (selectionChange)="selectionChanged($event)"
-    >
-      <mat-option *ngFor="let language of languages" [value]="language">
-        {{ language.value }}
-      </mat-option>
-    </mat-select>
-  </mat-form-field>
-</div>
+<mat-form-field style="width: 100px;">
+  <mat-select
+    [(ngModel)]="language"
+    name="language"
+    [compareWith]="compareObjects"
+    (selectionChange)="selectionChanged($event)"
+  >
+    <mat-option *ngFor="let language of languages" [value]="language">
+      {{ language.label }}
+    </mat-option>
+  </mat-select>
+</mat-form-field>

--- a/maths-club-app/src/app/components/language-switcher/language-switcher.component.scss
+++ b/maths-club-app/src/app/components/language-switcher/language-switcher.component.scss
@@ -1,7 +1,1 @@
-.form {
-  width: 30px;
-  margin-right: 10px;
-}
-.select {
-  width: 40px;
-}
+

--- a/maths-club-app/src/app/components/problem-card/problem-card.component.html
+++ b/maths-club-app/src/app/components/problem-card/problem-card.component.html
@@ -1,3 +1,3 @@
-<div class="problem" *ngIf="problemText">
-  <markdown [data]="problemText" katex></markdown>
+<div class="problem-container">
+  <markdown  id="problemMarkdown" [data]="problemText" katex></markdown>
 </div>

--- a/maths-club-app/src/app/components/problem-card/problem-card.component.scss
+++ b/maths-club-app/src/app/components/problem-card/problem-card.component.scss
@@ -1,3 +1,17 @@
-.problem{
-    margin-left: 10px;
+.problem-container {
+  padding: 1em;
+  max-width: 900px;
+  margin: auto;
+}
+
+// Styles to apply to rendered markdown
+#problemMarkdown {
+  img {
+    max-width: 500px;
+  }
+  @media only screen and (max-width: 500px) {
+    img {
+      max-width: 100%;
+    }
+  }
 }

--- a/maths-club-app/src/app/components/problem-card/problem-card.component.ts
+++ b/maths-club-app/src/app/components/problem-card/problem-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, OnInit, ViewEncapsulation } from "@angular/core";
 import { ProblemService } from "../../services/problem.service";
 import { ActivatedRoute } from "@angular/router";
 
@@ -6,6 +6,7 @@ import { ActivatedRoute } from "@angular/router";
   selector: "app-problem-card",
   templateUrl: "./problem-card.component.html",
   styleUrls: ["./problem-card.component.scss"],
+  encapsulation: ViewEncapsulation.None,
 })
 export class ProblemCardComponent implements OnInit {
   problemText: string;

--- a/maths-club-app/src/app/components/problems-list/problems-list.component.html
+++ b/maths-club-app/src/app/components/problems-list/problems-list.component.html
@@ -1,26 +1,14 @@
-<div
-  class="problems-list-container"
-  fxLayout="row wrap"
-  fxLayoutGap="16px grid"
->
-  <div
-    fxFlex.lg="16%"
-    fxFlex.xs="50%"
-    fxFlex.md="25%"
-    fxFlex.sm="33%"
+<div class="problems-list-container">
+  <mat-card
+    class="problem-card"
+    [routerLink]="[problem.slug]"
     *ngFor="let problem of problems"
   >
-    <mat-card class="problem-card" [routerLink]="[problem.slug]">
-      <mat-card-header>
-        <mat-card-subtitle>{{ problem.title }}</mat-card-subtitle>
-      </mat-card-header>
-      <img
-        mat-card-image
-        [src]="[
-          '/assets/maths-club-pack/cover_images/' + problem.slug + '.svg'
-        ]"
-        [alt]="problem.title"
-      />
-    </mat-card>
-  </div>
+    <h2 class="problem-title">{{ problem.title }}</h2>
+    <img
+      class="problem-image"
+      [src]="['/assets/maths-club-pack/cover_images/' + problem.slug + '.svg']"
+      [alt]="problem.title"
+    />
+  </mat-card>
 </div>

--- a/maths-club-app/src/app/components/problems-list/problems-list.component.scss
+++ b/maths-club-app/src/app/components/problems-list/problems-list.component.scss
@@ -1,17 +1,26 @@
+$min-item-width: 150px;
+$max-item-height: 250px;
+
 .problems-list-container {
-  display: flex;
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax($min-item-width, 1fr));
+  grid-template-rows: repeat(4, $max-item-height);
+  column-gap: 10px;
+  row-gap: 15px;
 }
 
 .problem-card {
-  width: 150px;
-  height: 200px;
-  margin-right: 10px;
-  margin-top: 10px;
-  margin-left: 5px;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  justify-content: center;
   cursor: pointer;
 }
 
-.problem-card > image {
-  width: 150px;
-  height: 150px;
+.problem-image {
+  width: 100%;
+}
+.problem-title {
+  margin: 0;
 }

--- a/maths-club-app/src/styles.scss
+++ b/maths-club-app/src/styles.scss
@@ -1,6 +1,10 @@
 /* You can add global styles to this file, and also import other style files */
 @import "./theme/my-theme.scss";
 
+html,
+body {
+  height: 100%;
+}
 body {
   margin: 0;
   font-family: Roboto, "Helvetica Neue", sans-serif;

--- a/maths-club-app/src/styles.scss
+++ b/maths-club-app/src/styles.scss
@@ -1,10 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
 @import "./theme/my-theme.scss";
 
-html,
-body {
-  height: 100%;
-}
 body {
   margin: 0;
   font-family: Roboto, "Helvetica Neue", sans-serif;


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
Fix toolbar and sidebar styles to remove double scrollbars and be responsive on desktop and mobile. Improve problem list grid and language picker. Expose markdown for styling.

@KingMike100 
I decided the solution implemented from the mat docs was more complicated than we would really need, and was struggling to get it working smoothly so I just removed it and went for a simpler css solution using grid.

Most of those magic layout tools (e.g. mat fx-grid, ion-col etc.) are just wrapping around regular css, so also good to know how to achieve layouts in vanilla - that way you can also use with any framework.  

Additionally, I realised we would want to apply styles to the rendered markdown (e.g. max image widths). By default angular blocks this (every component has it's own shadow dom, so something in `<markdown />` would not be accessible to outside styling unless using the deprecated `deep` selector. The workaround is to specify the `viewEncapsulation` to prevent this behaviour, and use the `markdown` directive instead of component.  

As an extra minor comment, I think we should refactor the `problem-card` component, as this is confusing (it isn't actually a card, but the rendered problem-detail). Probably best to do as we have the solution page also to decide what should be shared between them. 

## Git Issues

_Closes #_

## Screenshots/Videos

![SamiMathsClubApp](https://user-images.githubusercontent.com/10515065/87333682-4fe8ad80-c4f2-11ea-9ba7-0cb3dabfae1e.gif)
_responsive grid_

![localhost_4200_fr](https://user-images.githubusercontent.com/10515065/87334649-d487fb80-c4f3-11ea-9e64-efadb6b9261a.png)
_markdown with inherited max-width styles for images and content_
