### PR TITLE
add back button to problem navigation

### DIFF
--- a/maths-club-app/src/app/app.component.html
+++ b/maths-club-app/src/app/app.component.html
@@ -11,10 +11,13 @@
       </div>
     </mat-nav-list>
   </mat-sidenav>
-  <mat-sidenav-content>
+  <mat-sidenav-content *ngIf="appService.routeParams$ | async as params">
     <mat-toolbar color="primary">
-      <button mat-icon-button (click)="snav.toggle()">
+      <button mat-icon-button (click)="snav.toggle()" *ngIf="!params.slug">
         <mat-icon>menu</mat-icon>
+      </button>
+      <button mat-icon-button (click)="appService.goBack()" *ngIf="params.slug">
+        <mat-icon>arrow_back</mat-icon>
       </button>
       <span
         style="flex: 1; text-align: center;"

--- a/maths-club-app/src/app/services/app.service.ts
+++ b/maths-club-app/src/app/services/app.service.ts
@@ -20,6 +20,10 @@ export class AppService {
     this.title$.next(title);
   }
 
+  goBack() {
+    this.router.navigate([".."], { relativeTo: this.route, replaceUrl: true });
+  }
+
   /**
    * As the service sits outside the router-outlet, workaround to access
    * params that would otherwise only be passed down to children
@@ -27,6 +31,8 @@ export class AppService {
   private _subscribeToRouteChanges() {
     this.router.events.subscribe((e) => {
       if (e instanceof NavigationEnd) {
+        // update activated route to reflect routed component tree
+        this.route = this.route.root.firstChild;
         const params = this.route.root.firstChild.snapshot
           .params as IRouteParams;
         this.routeParams$.next(params);


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Toggles the menubar to show a back button on problem and notes pages, used for relative routing up the URL stack

## Screenshots

![image](https://user-images.githubusercontent.com/10515065/88948766-2e542980-d247-11ea-8d67-7b893de224ce.png)

![image](https://user-images.githubusercontent.com/10515065/88948735-24cac180-d247-11ea-8319-2a8fac7541ce.png)

