### PR TITLE
Add version to home screen, refactor notifications

### DIFF
--- a/.github/workflows/build-and-deploy-release.yml
+++ b/.github/workflows/build-and-deploy-release.yml
@@ -22,8 +22,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Write Google Services Json
+        run: cd maths-club-app/android && echo $GOOGLE_SERVICES_JSON > app/google-services.json
       - name: Generate Android Build
-        # create release app bundle (aab) and app assemble (apk)
+        # write google services to json from env, create release app bundle (aab) and app assemble (apk)
         run: cd maths-club-app/android && ./gradlew clean :app:bundleRelease :app:assembleRelease
       - name: Sign Android Bundle
         uses: r0adkll/sign-android-release@v1

--- a/maths-club-app/package.json
+++ b/maths-club-app/package.json
@@ -39,7 +39,7 @@
     "@angular/language-service": "~9.1.3",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
-    "@types/node": "^12.11.1",
+    "@types/node": "^14.0.27",
     "codelyzer": "^5.1.2",
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",

--- a/maths-club-app/src/app/app.component.html
+++ b/maths-club-app/src/app/app.component.html
@@ -8,6 +8,7 @@
       <div class="bottom-items">
         <a mat-list-item routerLink="privacy">Privacy Policy</a>
         <a mat-list-item routerLink="app-terms">Terms and Conditions</a>
+        <div id="version">v{{ version }}</div>
       </div>
     </mat-nav-list>
   </mat-sidenav>

--- a/maths-club-app/src/app/app.component.scss
+++ b/maths-club-app/src/app/app.component.scss
@@ -15,3 +15,9 @@ mat-sidenav-content {
   position: absolute;
   bottom: 0;
 }
+
+#version {
+  padding: 5px 16px;
+  opacity: 0.5;
+  text-align: left;
+}

--- a/maths-club-app/src/app/app.component.ts
+++ b/maths-club-app/src/app/app.component.ts
@@ -9,6 +9,7 @@ import {
   PushNotificationToken,
   PushNotificationActionPerformed,
 } from "@capacitor/core";
+import { environment } from "src/environments/environment";
 
 const { PushNotifications, Modals } = Plugins;
 
@@ -20,6 +21,7 @@ const { PushNotifications, Modals } = Plugins;
   animations: [slideTransition],
 })
 export class AppComponent implements OnInit {
+  version = environment.APP_VERSION;
   constructor(public appService: AppService) {}
   getRouteAnimationState(outlet: RouterOutlet) {
     return (
@@ -53,13 +55,13 @@ export class AppComponent implements OnInit {
     PushNotifications.addListener(
       "pushNotificationReceived",
       (notification: PushNotification) => {
-       // alert("Push received: " + JSON.stringify(notification));
-       console.log("Push Received: ", notification);
+        // alert("Push received: " + JSON.stringify(notification));
+        console.log("Push Received: ", notification);
 
-       let alertRet = Modals.alert({
-         title: notification.title,
-         message: notification.body
-       })
+        let alertRet = Modals.alert({
+          title: notification.title,
+          message: notification.body,
+        });
       }
     );
 

--- a/maths-club-app/src/app/app.component.ts
+++ b/maths-club-app/src/app/app.component.ts
@@ -1,17 +1,10 @@
-import { Component, ViewEncapsulation, OnInit } from "@angular/core";
+import { Component, ViewEncapsulation } from "@angular/core";
 import { AppService } from "./services/app.service";
 import { RouterOutlet } from "@angular/router";
 import { slideTransition } from "./animations";
 
-import {
-  Plugins,
-  PushNotification,
-  PushNotificationToken,
-  PushNotificationActionPerformed,
-} from "@capacitor/core";
 import { environment } from "src/environments/environment";
-
-const { PushNotifications, Modals } = Plugins;
+import { NotificationService } from "./services/notification.service";
 
 @Component({
   selector: "app-root",
@@ -20,56 +13,19 @@ const { PushNotifications, Modals } = Plugins;
   encapsulation: ViewEncapsulation.None,
   animations: [slideTransition],
 })
-export class AppComponent implements OnInit {
+export class AppComponent {
   version = environment.APP_VERSION;
-  constructor(public appService: AppService) {}
+  constructor(
+    public appService: AppService,
+    public notifications: NotificationService
+  ) {
+    // this.notifications.init()
+  }
   getRouteAnimationState(outlet: RouterOutlet) {
     return (
       outlet &&
       outlet.activatedRouteData &&
       outlet.activatedRouteData["animation"]
-    );
-  }
-
-  ngOnInit() {
-    console.log("Initiliaizng HomePage");
-
-    PushNotifications.requestPermission().then((result) => {
-      if (result.granted) {
-        PushNotifications.register();
-      }
-    });
-
-    PushNotifications.addListener(
-      "registration",
-      (token: PushNotificationToken) => {
-        alert("Push registration success, token:" + token.value);
-        console.log("Token Value", token.value);
-      }
-    );
-
-    PushNotifications.addListener("registrationError", (error: any) => {
-      alert("Error on registration: " + JSON.stringify(error));
-    });
-
-    PushNotifications.addListener(
-      "pushNotificationReceived",
-      (notification: PushNotification) => {
-        // alert("Push received: " + JSON.stringify(notification));
-        console.log("Push Received: ", notification);
-
-        let alertRet = Modals.alert({
-          title: notification.title,
-          message: notification.body,
-        });
-      }
-    );
-
-    PushNotifications.addListener(
-      "pushNotificationActionPerformed",
-      (notification: PushNotificationActionPerformed) => {
-        alert("Push action performed: " + JSON.stringify(notification));
-      }
     );
   }
 }

--- a/maths-club-app/src/app/services/notification.service.spec.ts
+++ b/maths-club-app/src/app/services/notification.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from "@angular/core/testing";
+
+import { NotificationService } from "./notification.service";
+
+describe("NotificationService", () => {
+  let service: NotificationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NotificationService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/maths-club-app/src/app/services/notification.service.ts
+++ b/maths-club-app/src/app/services/notification.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from "@angular/core";
+import {
+  Plugins,
+  PushNotification,
+  PushNotificationToken,
+  PushNotificationActionPerformed,
+} from "@capacitor/core";
+
+const { PushNotifications, Modals } = Plugins;
+
+@Injectable({
+  providedIn: "root",
+})
+export class NotificationService {
+  constructor() {}
+
+  init() {
+    PushNotifications.requestPermission().then((result) => {
+      if (result.granted) {
+        PushNotifications.register();
+      }
+    });
+
+    PushNotifications.addListener(
+      "registration",
+      (token: PushNotificationToken) => {
+        alert("Push registration success, token:" + token.value);
+        console.log("Token Value", token.value);
+      }
+    );
+
+    PushNotifications.addListener("registrationError", (error: any) => {
+      alert("Error on registration: " + JSON.stringify(error));
+    });
+
+    PushNotifications.addListener(
+      "pushNotificationReceived",
+      (notification: PushNotification) => {
+        // alert("Push received: " + JSON.stringify(notification));
+        console.log("Push Received: ", notification);
+
+        let alertRet = Modals.alert({
+          title: notification.title,
+          message: notification.body,
+        });
+      }
+    );
+
+    PushNotifications.addListener(
+      "pushNotificationActionPerformed",
+      (notification: PushNotificationActionPerformed) => {
+        alert("Push action performed: " + JSON.stringify(notification));
+      }
+    );
+  }
+}

--- a/maths-club-app/src/environments/environment.prod.ts
+++ b/maths-club-app/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  APP_VERSION: require("../../package.json").version,
 };

--- a/maths-club-app/src/environments/environment.prod.ts
+++ b/maths-club-app/src/environments/environment.prod.ts
@@ -1,4 +1,6 @@
+import PACKAGE_JSON from "../../package.json";
+
 export const environment = {
-  production: true,
-  APP_VERSION: require("../../package.json").version,
+  production: false,
+  APP_VERSION: PACKAGE_JSON.version,
 };

--- a/maths-club-app/src/environments/environment.ts
+++ b/maths-club-app/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  APP_VERSION: require("../../package.json").version,
 };
 
 /*

--- a/maths-club-app/src/environments/environment.ts
+++ b/maths-club-app/src/environments/environment.ts
@@ -1,10 +1,11 @@
 // This file can be replaced during build by using the `fileReplacements` array.
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
+import PACKAGE_JSON from "../../package.json";
 
 export const environment = {
   production: false,
-  APP_VERSION: require("../../package.json").version,
+  APP_VERSION: PACKAGE_JSON.version,
 };
 
 /*

--- a/maths-club-app/tsconfig.json
+++ b/maths-club-app/tsconfig.json
@@ -11,10 +11,8 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2015",
-    "lib": [
-      "es2018",
-      "dom"
-    ]
+    "lib": ["es2018", "dom"],
+    "types": ["node"]
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/maths-club-app/tsconfig.json
+++ b/maths-club-app/tsconfig.json
@@ -7,12 +7,13 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2015",
-    "lib": ["es2018", "dom"],
-    "types": ["node"]
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/maths-club-app/yarn.lock
+++ b/maths-club-app/yarn.lock
@@ -1169,10 +1169,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.14.tgz#24a0b5959f16ac141aeb0c5b3cd7a15b7c64cbce"
   integrity sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==
 
-"@types/node@^12.11.1":
-  version "12.12.47"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.47.tgz#5007b8866a2f9150de82335ca7e24dd1d59bdfb5"
-  integrity sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A==
+"@types/node@^14.0.27":
+  version "14.0.27"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
+  integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
 
 "@types/q@^0.0.32":
   version "0.0.32"


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description
@KingMike100 
I've added a short code snippet to read the version number from the package.json and display in the app (see screenshot), and fixed the release script to automatically publish releases to the beta channel on google play. 

I've also moved the notifications scripts to their own service and commented out an initialisation script (called from app.module) which we can uncomment once working fully as intended (we might also want to check if the device supports them first also).

## Screenshots/Videos

![image](https://user-images.githubusercontent.com/10515065/89570427-09c5f780-d7db-11ea-971f-cbe7e0fd24da.png)

